### PR TITLE
fix: svgs with 0 in dasharray

### DIFF
--- a/packages/abstract-document/CHANGELOG.md
+++ b/packages/abstract-document/CHANGELOG.md
@@ -2,13 +2,19 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased](https://github.com/dividab/abstract-visuals/compare/abstract-document@6.8.0...master)
+## [Unreleased](https://github.com/dividab/abstract-visuals/compare/abstract-document@6.8.1...master)
 
 ### Added
 
 ### Changed
 
 ### Removed
+
+## [v6.8.1](https://github.com/dividab/abstract-visuals/compare/abstract-document@6.8.0...abstract-document@6.8.1) - 2022-04-07
+
+### Changed
+
+- Fixed crash when an SVG has 0 in a dasharray
 
 ## [v6.8.0](https://github.com/dividab/abstract-visuals/compare/abstract-document@6.7.2...abstract-document@6.8.0) - 2022-03-04
 

--- a/packages/abstract-document/src/abstract-document-exporters/__tests__/pdf/test-defs/single-image-svg-dasharray.tsx
+++ b/packages/abstract-document/src/abstract-document-exporters/__tests__/pdf/test-defs/single-image-svg-dasharray.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+import { ExportTestDef } from "../export-test-def";
+import * as AI from "../../../../../../abstract-image";
+import { Paragraph, AbstractDoc, Section, Image } from "../../../../abstract-document-jsx";
+
+const svgEncoded =
+  '<?xml version ="1.0" encoding="utf-8"?>' +
+  '<svg version ="1.1" id="missingImage" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" ' +
+  'width="640" height="480" viewBox="0 0 640 480" preserveAspectRatio="xMinYMin meet" xml:space="preserve">' +
+  "<svg>" +
+  '<line x1="62.61" y1="51.68" x2="62.61" y2="148.08" fill="none" stroke="#000" stroke-dasharray="0 0 0 0 0 0 2.03 2.03 2.03 2.03 2.03 2.03" stroke-linecap="round" stroke-miterlimit="10" stroke-width=".5"/>' +
+  '<tspan x="0" dy="1.5em"> Missing image:</tspan>' +
+  "</svg>" +
+  "</svg>";
+
+const imageResource = {
+  id: "svg",
+  renderScale: 1.0,
+  abstractImage: AI.createAbstractImage(
+    {
+      x: 0,
+      y: 0,
+    },
+    {
+      width: 200,
+      height: 150,
+    },
+    AI.white,
+    [AI.createBinaryImage({ x: 0, y: 0 }, { x: 640, y: 480 }, "svg", new TextEncoder().encode(svgEncoded))]
+  ),
+};
+
+export const test: ExportTestDef = {
+  name: "Single image svg dasharray",
+  abstractDocJsx: (
+    <AbstractDoc>
+      <Section>
+        <Paragraph>
+          <Image width={640} height={480} imageResource={imageResource} />
+        </Paragraph>
+      </Section>
+    </AbstractDoc>
+  ),
+  expectedPdfJson: {
+    formImage: {
+      Transcoder: "pdf2json@1.2.3 [https://github.com/modesty/pdf2json]",
+      Agency: "",
+      Id: {
+        AgencyId: "",
+        Name: "",
+        MC: false,
+        Max: 1,
+        Parent: "",
+      },
+      Pages: [
+        {
+          Height: 52.625,
+          HLines: [],
+          VLines: [
+            {
+              dsh: 1,
+              x: 12.522,
+              y: 10.336,
+              w: 2.4,
+              l: 19.28,
+            },
+          ],
+          Fills: [
+            {
+              x: 0,
+              y: 0,
+              w: 0,
+              h: 0,
+              clr: 1,
+            },
+          ],
+          Texts: [],
+          Fields: [],
+          Boxsets: [],
+        },
+      ],
+      Width: 37.188,
+    },
+  },
+};

--- a/packages/abstract-document/src/abstract-document-exporters/pdf/render-image.ts
+++ b/packages/abstract-document/src/abstract-document-exporters/pdf/render-image.ts
@@ -74,6 +74,32 @@ function abstractComponentToPdf(
           }
         });
 
+        ["stroke-dasharray="].forEach((t) => {
+          let index = 0;
+          while (true) {
+            index = svgUpdated.indexOf(t, index);
+            if (index === -1) break;
+            let indexStart = svgUpdated.indexOf('"', index) + 1;
+            let indexEnd = svgUpdated.indexOf('"', indexStart);
+            index = indexEnd;
+
+            let dasharray = svgUpdated.substring(indexStart, indexEnd);
+
+            console.log(dasharray);
+
+            dasharray = dasharray
+              .split(" ")
+              .map((x) => parseFloat(x))
+              .filter((x) => x !== 0)
+              .join(" ");
+
+            svgUpdated =
+              svgUpdated.substring(0, indexStart) + dasharray + svgUpdated.substring(indexEnd, svgUpdated.length);
+
+            console.log(svgUpdated);
+          }
+        });
+
         const imageWidth = component.bottomRight.x - component.topLeft.x;
         const imageHeight = component.bottomRight.y - component.topLeft.y;
         svgToPdfKit(pdf, svgUpdated, component.topLeft.x, component.topLeft.y, {

--- a/packages/abstract-document/src/abstract-document-exporters/pdf/render-image.ts
+++ b/packages/abstract-document/src/abstract-document-exporters/pdf/render-image.ts
@@ -85,8 +85,6 @@ function abstractComponentToPdf(
 
             let dasharray = svgUpdated.substring(indexStart, indexEnd);
 
-            console.log(dasharray);
-
             dasharray = dasharray
               .split(" ")
               .map((x) => parseFloat(x))
@@ -95,8 +93,6 @@ function abstractComponentToPdf(
 
             svgUpdated =
               svgUpdated.substring(0, indexStart) + dasharray + svgUpdated.substring(indexEnd, svgUpdated.length);
-
-            console.log(svgUpdated);
           }
         });
 


### PR DESCRIPTION
PDFKIT crashes if you have a 0 in the dasharray.
The numbers in the dasharray represents the length of a dash and the length of a gap alternating.
Which means a length of 0 would do nothing and is safe to remove.