### PR TITLE
start binaryimage rotation

### DIFF
--- a/packages/abstract-document/src/abstract-document-exporters/pdf/render-image.ts
+++ b/packages/abstract-document/src/abstract-document-exporters/pdf/render-image.ts
@@ -100,6 +100,12 @@ function abstractComponentToPdf(
           }
         });
 
+        // svgToPdfKit doesn't seem to have great support currently, need to find workaround.
+
+        // if (component.rotation) {
+        //   svgUpdated = `<svg transform="rotate(${component.rotation.x} ${component.rotation.y} ${component.rotation.z})">${svgUpdated}</svg>`;
+        // }
+
         const imageWidth = component.bottomRight.x - component.topLeft.x;
         const imageHeight = component.bottomRight.y - component.topLeft.y;
         svgToPdfKit(pdf, svgUpdated, component.topLeft.x, component.topLeft.y, {

--- a/packages/abstract-image/src/exporters/react-svg-export-image.tsx
+++ b/packages/abstract-image/src/exporters/react-svg-export-image.tsx
@@ -98,6 +98,11 @@ function _visit(key: string, component: AbstractImage.Component): Array<React.Re
           width={component.bottomRight.x - component.topLeft.x}
           height={component.bottomRight.y - component.topLeft.y}
           id={makeIdAttr(component.id)}
+          {...(component.rotation && {
+            style: {
+              transform: `rotateX(${component.rotation.x}deg) rotateY(${component.rotation.y}deg) rotateZ(${component.rotation.z}deg)`,
+            },
+          })}
           href={url}
         />,
       ];

--- a/packages/abstract-image/src/exporters/svg-export-image.ts
+++ b/packages/abstract-image/src/exporters/svg-export-image.ts
@@ -36,6 +36,9 @@ function abstractComponentToSVG(component: AbstractImage.Component): string {
           width: (component.bottomRight.x - component.topLeft.x).toString(),
           height: (component.bottomRight.y - component.topLeft.y).toString(),
           href: url,
+          style: component.rotation
+            ? `transform: rotateX(${component.rotation.x}deg) rotateY(${component.rotation.y}deg) rotateZ(${component.rotation.z}deg)`
+            : "",
         },
         []
       );

--- a/packages/abstract-image/src/model/component.ts
+++ b/packages/abstract-image/src/model/component.ts
@@ -31,6 +31,7 @@ export interface BinaryImage {
   readonly format: BinaryFormat;
   readonly data: ImageData;
   readonly id: string | undefined;
+  readonly rotation: (Point.Point & { readonly z: number }) | undefined;
 }
 
 export type ImageData = ImageBytes | ImageUrl;
@@ -50,7 +51,8 @@ export function createBinaryImage(
   bottomRight: Point.Point,
   format: BinaryFormat,
   data: ImageData,
-  id?: string
+  id?: string,
+  rotation?: Point.Point & { readonly z: number }
 ): BinaryImage {
   return {
     type: "binaryimage",
@@ -59,6 +61,7 @@ export function createBinaryImage(
     format: format,
     data: data,
     id: id,
+    rotation,
   };
 }
 


### PR DESCRIPTION
Doesn't seem very easy to get 3d rotation working with [SVG-to-PDFKit.](https://github.com/alafr/SVG-to-PDFKit/issues/167).

This is the parsing code:
![image](https://user-images.githubusercontent.com/18581780/171436323-33f1cea5-d151-4ade-9588-0db89c58c891.png)

Will see if it's possible the rotation.

