### PR TITLE
Fix for format value in Abstract-chart

### DIFF
--- a/packages/abstract-chart/src/axis.ts
+++ b/packages/abstract-chart/src/axis.ts
@@ -3,6 +3,8 @@ import { exhaustiveCheck } from "ts-exhaustive-check";
 
 export type Axis = LinearAxis | LogarithmicAxis | DiscreteAxis;
 
+export type NumberFormat = "compact" | "scientific" | "none";
+
 export type AxisBase = {
   readonly label?: string;
   readonly labelRotation?: number;
@@ -15,6 +17,7 @@ export type AxisBase = {
   readonly axisFontSize?: number;
   readonly id?: string;
   readonly noTicks?: boolean;
+  readonly numberFormat?: NumberFormat;
 };
 
 export type LinearAxis = AxisBase & { readonly type: "linear"; readonly min: number; readonly max: number };
@@ -29,7 +32,8 @@ export function createLinearAxis(
   thickness?: number,
   axisColor?: Color,
   id?: string,
-  noTicks?: boolean
+  noTicks?: boolean,
+  numberFormat?: NumberFormat
 ): LinearAxis {
   return {
     type: "linear",
@@ -43,6 +47,7 @@ export function createLinearAxis(
     axisColor,
     id,
     noTicks,
+    numberFormat,
   };
 }
 

--- a/packages/abstract-chart/src/axis.ts
+++ b/packages/abstract-chart/src/axis.ts
@@ -254,8 +254,7 @@ export function axisMax(axis: Axis): number {
     case "discrete":
       return axis.points.at(-1)?.value ?? 0;
     default:
-      exhaustiveCheck(axis);
-      return 0;
+      return exhaustiveCheck(axis);
   }
 }
 

--- a/packages/abstract-chart/src/chart.ts
+++ b/packages/abstract-chart/src/chart.ts
@@ -9,6 +9,7 @@ import {
   transformValue,
   transformPoint,
   DiscreteAxisPoint,
+  NumberFormat,
 } from "./axis.js";
 import {
   AbstractImage,
@@ -764,7 +765,7 @@ export function generateDataAxisesX(
           createLine(start, end, chart.xGrid.color, chart.xGrid.thickness),
           createText(
             textPos,
-            formatNumber(y),
+            formatNumber(y, axis.numberFormat),
             chart.font,
             axis.tickFontSize ?? chart.fontSize,
             axis.labelColor ?? black,
@@ -874,7 +875,7 @@ export function generateDataAxisesY(
           createLine(start, end, chart.xGrid.color, chart.xGrid.thickness),
           createText(
             textPos,
-            formatNumber(y),
+            formatNumber(y, axis.numberFormat),
             chart.font,
             axis.tickFontSize ?? chart.fontSize,
             axis.labelColor ?? black,
@@ -1312,7 +1313,7 @@ export function generateXAxisLabels(
     const position = createPoint(transformValue(l.value, xMin, xMax, axis), y);
     return createText(
       position,
-      l.label ?? formatNumber(l.value),
+      l.label ?? formatNumber(l.value, axis.numberFormat),
       chart.font,
       axis.tickFontSize ?? chart.fontSize,
       axis.labelColor ?? black,
@@ -1400,7 +1401,7 @@ export function generateYAxisLabels(
     const position = createPoint(x, transformValue(l.value, yMin, yMax, yAxis));
     return createText(
       position,
-      l.label ?? formatNumber(l.value),
+      l.label ?? formatNumber(l.value, yAxis.numberFormat),
       chart.font,
       yAxis.tickFontSize ?? chart.fontSize,
       yAxis.labelColor ?? black,
@@ -1445,14 +1446,23 @@ export function generateYAxisLabel(
   );
 }
 
-function formatNumber(n: number): string {
-  if (Math.abs(n) >= 10000000) {
-    return numberToString(n / 1000000) + "m";
+function formatNumber(n: number, format: NumberFormat = "compact"): string {
+  switch (format) {
+    case "compact":
+      if (Math.abs(n) >= 10000000) {
+        return numberToString(n / 1000000) + "m";
+      }
+      if (Math.abs(n) >= 10000) {
+        return numberToString(n / 1000) + "k";
+      }
+      return numberToString(n);
+    case "scientific":
+      return parseFloat(n.toPrecision(5)).toExponential();
+    case "none":
+      return numberToString(n);
+    default:
+      return exhaustiveCheck(format);
   }
-  if (Math.abs(n) >= 10000) {
-    return numberToString(n / 1000) + "k";
-  }
-  return numberToString(n);
 }
 
 function numberToString(n: number): string {

--- a/packages/abstract-chart/src/chart.ts
+++ b/packages/abstract-chart/src/chart.ts
@@ -1446,10 +1446,10 @@ export function generateYAxisLabel(
 }
 
 function formatNumber(n: number): string {
-  if (n >= 10000000) {
+  if (Math.abs(n) >= 10000000) {
     return numberToString(n / 1000000) + "m";
   }
-  if (n >= 10000) {
+  if (Math.abs(n) >= 10000) {
     return numberToString(n / 1000) + "k";
   }
   return numberToString(n);

--- a/packages/abstract-chart/src/chart.ts
+++ b/packages/abstract-chart/src/chart.ts
@@ -10,7 +10,31 @@ import {
   transformPoint,
   DiscreteAxisPoint,
 } from "./axis.js";
-import { AbstractImage, black, Color, Component, createAbstractImage, createEllipse, createGroup, createLine, createPoint, createPolygon, createPolyLine, createRectangle, createSize, createText, gray, GrowthDirection, lightGray, Point, Polygon, Size, solidLine, transparent, white } from "abstract-image";
+import {
+  AbstractImage,
+  black,
+  Color,
+  Component,
+  createAbstractImage,
+  createEllipse,
+  createGroup,
+  createLine,
+  createPoint,
+  createPolygon,
+  createPolyLine,
+  createRectangle,
+  createSize,
+  createText,
+  gray,
+  GrowthDirection,
+  lightGray,
+  Point,
+  Polygon,
+  Size,
+  solidLine,
+  transparent,
+  white,
+} from "abstract-image";
 
 // tslint:disable:max-file-line-count
 
@@ -529,13 +553,7 @@ export function renderChart(chart: Chart): AbstractImage {
 }
 
 export function generateBackground(xMin: number, xMax: number, yMin: number, yMax: number, chart: Chart): Component {
-  return createRectangle(
-    createPoint(xMin, yMax),
-    createPoint(xMax, yMin),
-    transparent,
-    0,
-    chart.backgroundColor
-  );
+  return createRectangle(createPoint(xMin, yMax), createPoint(xMax, yMin), transparent, 0, chart.backgroundColor);
 }
 
 export function xAxises(
@@ -1068,14 +1086,7 @@ function isInside(xMin: number, xMax: number, yMin: number, yMax: number, p: Poi
   return p.x >= xMin && p.x <= xMax && p.y <= yMin && p.y >= yMax;
 }
 
-function moveInside(
-  xMin: number,
-  xMax: number,
-  yMin: number,
-  yMax: number,
-  inside: Point,
-  outside: Point
-): Point {
+function moveInside(xMin: number, xMax: number, yMin: number, yMax: number, inside: Point, outside: Point): Point {
   const xMinYMin = createPoint(xMin, yMin);
   const xMinYMax = createPoint(xMin, yMax);
   const xMaxYMin = createPoint(xMax, yMin);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,8 +297,8 @@ importers:
   packages/abstract-visuals-example:
     dependencies:
       abstract-3d:
-        specifier: ^2.3.25
-        version: 2.3.25(@types/react@19.2.15)(@types/three@0.180.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^2.3.26
+        version: 2.3.26(@types/react@19.2.15)(@types/three@0.180.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       abstract-chart:
         specifier: ^12.0.56
         version: 12.0.56(react@19.2.6)
@@ -2194,8 +2194,8 @@ packages:
   abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
 
-  abstract-3d@2.3.25:
-    resolution: {integrity: sha512-6C44gqat4PEDR0Xv/3b+X9prvYDjCbCtFkEHSlAWhqA7NbfQLaiP2neJvifYcFzVm+jxQX/raBWmR5DLW3CKgg==}
+  abstract-3d@2.3.26:
+    resolution: {integrity: sha512-jH6BggaTrkd2JpkDlGclF1crehHaFumLDB/TWRfjt+Wc0qVUWQ1gIphCmlZ6wZIZ42XP4RG9v7Xak1DyOlNRMA==}
     peerDependencies:
       react: ^19.2.0
 
@@ -9213,7 +9213,7 @@ snapshots:
 
   abbrev@1.1.1: {}
 
-  abstract-3d@2.3.25(@types/react@19.2.15)(@types/three@0.180.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  abstract-3d@2.3.26(@types/react@19.2.15)(@types/three@0.180.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@react-three/drei': 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(three@0.184.0))(@types/react@19.2.15)(@types/three@0.180.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(three@0.184.0)
       '@react-three/fiber': 9.6.1(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(three@0.184.0)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,6 +34,7 @@ minimumReleaseAgeExclude:
   - abstract-3d@2.3.23
   - abstract-3d@2.3.24
   - abstract-3d@2.3.25
+  - abstract-3d@2.3.26
 
 overrides:
   three-stdlib: "^2.36.0"


### PR DESCRIPTION
Fixes number formatting, as we previously only compared for positive values, which made negative values not format. This resulted in inconsistent axis formatting:

<img width="706" height="423" alt="image" src="https://github.com/user-attachments/assets/cccb8020-2b50-4749-9377-8019c1277fd1" />

Also added the possibility to choose if we want to format the values or not, as this is needed for Nibe. 
